### PR TITLE
Make grid_card the base element of grid_card_text

### DIFF
--- a/R/grid_card_text.R
+++ b/R/grid_card_text.R
@@ -93,20 +93,21 @@ grid_card_text <- function(area,
     wrapping_tag <- htmltools::tags[[wrapping_tag]]
   }
 
-  grid_place(
-    area = area,
-    htmltools::tags$div(
-      class = "card grid_card_text",
-      style = htmltools::css(
-        `align-items` = alignment
-      ),
+  update_el(
+    grid_card(
+      area = area,
       wrapping_tag(
         htmltools::tagList(
           icon,
           content
         )
       ),
+      ...,
       if (is_title) htmltools::tags$head(htmltools::tags$title(content))
+    ),
+    classes = c("grid_card_text"),
+    styles = list(
+      `align-items` = alignment
     )
   )
 }


### PR DESCRIPTION
Fixes bug from #13 where dot args were not actually being passed through to `grid_card()`. Changes are that the base element rather than just a div is now `grid_card()` with dots supplied. 